### PR TITLE
support uploads larger than 2GB

### DIFF
--- a/uploadprogress.c
+++ b/uploadprogress.c
@@ -69,7 +69,7 @@ PHPAPI extern int (*php_rfc1867_callback)(unsigned int , void *, void **);
 static int uploadprogress_php_rfc1867_file(unsigned int event, void  *event_data, void **data)
 {
     uploadprogress_data *progress;
-    int read_bytes;
+    size_t read_bytes;
     zend_bool get_contents = INI_BOOL("uploadprogress.get_contents");
 
     progress = *data;


### PR DESCRIPTION
Uploadprogress only works for uploads smaller than 2GB. If a bigger amount of data is being uploaded, the progressbar stops at 2GB, and then the upload counter shows 16EB.

Changing the type of read_bytes from int to size_t solves the problem.